### PR TITLE
Support multiple AWS Accounts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Support multiple AWS Accounts.
+
 ## 0.1.0
 
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,22 @@ A Terraform module to create an Amazon Certificate Manager (ACM) certificate wit
 
 ```hcl
 resource "aws_route53_zone" "default" {
-  name = "azavea.com"
+  name = "linaro.org"
 }
 
 module "cert" {
   source = "github.com/azavea/terraform-aws-acm-certificate?ref=0.1.0"
 
-  domain_name               = "azavea.com"
-  subject_alternative_names = ["*.azavea.com"]
+  providers = {
+    aws.acm_account     = "aws.cert-account"
+    aws.route53_account = "aws.route53-account"
+  }
+
+  domain_name               = "linaro.org"
+  subject_alternative_names = [
+    "staging.linaro.org"
+    "*.linaro.org"
+  ]
   hosted_zone_id            = "${aws_route53_zone.default.zone_id}"
   validation_record_ttl     = "60"
 }
@@ -25,6 +33,7 @@ module "cert" {
 - `subject_alternative_names` - Subject alternative domain names
 - `hosted_zone_id` - Route 53 hosted zone ID for `domain_name`
 - `validation_record_ttl` - Route 53 record time-to-live (TTL) for validation record (default: `60`)
+- `providers` - AWS Account from root folder
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,29 @@
+provider "aws" {
+  alias = "acm_account"
+}
+
+provider "aws" {
+  alias = "route53_account"
+}
+
 resource "aws_acm_certificate" "default" {
+  provider                  = "aws.acm_account"
   domain_name               = "${var.domain_name}"
   subject_alternative_names = ["${var.subject_alternative_names}"]
   validation_method         = "DNS"
+
+  tags {
+    Name = "${var.domain_name}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_route53_record" "validation" {
-  count = "${length(var.subject_alternative_names) + 1}"
+  provider = "aws.route53_account"
+  count    = "${length(var.subject_alternative_names) + 1}"
 
   name    = "${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_name")}"
   type    = "${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_type")}"
@@ -15,6 +33,7 @@ resource "aws_route53_record" "validation" {
 }
 
 resource "aws_acm_certificate_validation" "default" {
+  provider        = "aws.acm_account"
   certificate_arn = "${aws_acm_certificate.default.arn}"
 
   validation_record_fqdns = [


### PR DESCRIPTION
Add `lifecycle` for certificates.
Tag certificates with `Name`:`${var.domain_name}`