### PR TITLE
Adds support for ACM cert to be created in a given region

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,18 @@ module "cert" {
   subject_alternative_names = ["*.azavea.com"]
   hosted_zone_id            = "${aws_route53_zone.default.zone_id}"
   validation_record_ttl     = "60"
+  cert_region               = "us-east-1"
 }
 ```
 
 ## Variables
 
-- `domain_name` - Primary domain name associated with certificate
-- `subject_alternative_names` - Subject alternative domain names
-- `hosted_zone_id` - Route 53 hosted zone ID for `domain_name`
-- `validation_record_ttl` - Route 53 record time-to-live (TTL) for validation record (default: `60`)
+-   `domain_name` - Primary domain name associated with certificate
+-   `subject_alternative_names` - Subject alternative domain names
+-   `hosted_zone_id` - Route 53 hosted zone ID for `domain_name`
+-   `validation_record_ttl` - Route 53 record time-to-live (TTL) for validation record (default: `60`)
+-   `cert_region` - The region in which the ACM certificate will be created
 
 ## Outputs
 
-- `arn` - The Amazon Resource Name (ARN) of the ACM certificate
+-   `arn` - The Amazon Resource Name (ARN) of the ACM certificate

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,12 @@ resource "aws_acm_certificate" "default" {
   domain_name               = "${var.domain_name}"
   subject_alternative_names = ["${var.subject_alternative_names}"]
   validation_method         = "DNS"
+  provider                  = "aws.cert"
+
+  tags {
+    Name      = "${var.domain_name}"
+    terraform = "true"
+  }
 }
 
 resource "aws_route53_record" "validation" {
@@ -16,6 +22,7 @@ resource "aws_route53_record" "validation" {
 
 resource "aws_acm_certificate_validation" "default" {
   certificate_arn = "${aws_acm_certificate.default.arn}"
+  provider        = "aws.cert"
 
   validation_record_fqdns = [
     "${aws_route53_record.validation.*.fqdn}",

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  alias  = "cert"
+  region = "${var.cert_region}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,3 +9,8 @@ variable "hosted_zone_id" {}
 variable "validation_record_ttl" {
   default = "60"
 }
+
+variable "cert_region" {
+  description = "region to keep your certificate. Use us-east-1 for CloudFront"
+  default     = "us-east-1"
+}


### PR DESCRIPTION
There is already a multiple-provider implementation by @morancj at https://github.com/azavea/terraform-aws-acm-certificate/compare/develop...morancj:develop, but I didn't see that before working on this.

Happy to switch this to a pass-provider approach as well, if that suits better.