### PR TITLE
Adds clean support for multiple providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ module "cert" {
   source = "github.com/azavea/terraform-aws-acm-certificate?ref=0.1.0"
 
   providers = {
-    aws.acm_account     = "aws.cert-account"
-    aws.route53_account = "aws.route53-account"
+    aws.acm_account     = "aws.certificates"
+    aws.route53_account = "aws.dns"
   }
 
   domain_name               = "azavea.com"
@@ -22,15 +22,26 @@ module "cert" {
   hosted_zone_id            = "${aws_route53_zone.default.zone_id}"
   validation_record_ttl     = "60"
 }
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "certificates"
+}
+
+provider "aws" {
+  region = "us-west-2"
+  alias  = "dns"
+}
 ```
 
 ## Variables
 
--   `domain_name` - Primary domain name associated with certificate
--   `subject_alternative_names` - Subject alternative domain names
--   `hosted_zone_id` - Route 53 hosted zone ID for `domain_name`
--   `validation_record_ttl` - Route 53 record time-to-live (TTL) for validation record (default: `60`)
+- `domain_name` - Primary domain name associated with certificate. Also used for the Name tag of the ACM certificate.
+- `subject_alternative_names` - Subject alternative domain names.
+- `hosted_zone_id` - Route 53 hosted zone ID for `domain_name`.
+- `validation_record_ttl` - Route 53 record time-to-live (TTL) for validation record (default: `60`).
+- `tags` - A map of extra tags that is associated with the ACM Certificate.
 
 ## Outputs
 
--   `arn` - The Amazon Resource Name (ARN) of the ACM certificate
+- `arn` - The Amazon Resource Name (ARN) of the ACM certificate

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ resource "aws_route53_zone" "default" {
 module "cert" {
   source = "github.com/azavea/terraform-aws-acm-certificate?ref=0.1.0"
 
+  providers = {
+    aws.acm_account     = "aws.cert-account"
+    aws.route53_account = "aws.route53-account"
+  }
+
   domain_name               = "azavea.com"
   subject_alternative_names = ["*.azavea.com"]
   hosted_zone_id            = "${aws_route53_zone.default.zone_id}"
@@ -21,11 +26,11 @@ module "cert" {
 
 ## Variables
 
-- `domain_name` - Primary domain name associated with certificate
-- `subject_alternative_names` - Subject alternative domain names
-- `hosted_zone_id` - Route 53 hosted zone ID for `domain_name`
-- `validation_record_ttl` - Route 53 record time-to-live (TTL) for validation record (default: `60`)
+-   `domain_name` - Primary domain name associated with certificate
+-   `subject_alternative_names` - Subject alternative domain names
+-   `hosted_zone_id` - Route 53 hosted zone ID for `domain_name`
+-   `validation_record_ttl` - Route 53 record time-to-live (TTL) for validation record (default: `60`)
 
 ## Outputs
 
-- `arn` - The Amazon Resource Name (ARN) of the ACM certificate
+-   `arn` - The Amazon Resource Name (ARN) of the ACM certificate

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,14 @@
 resource "aws_acm_certificate" "default" {
+  provider                  = "aws.acm_account"
   domain_name               = "${var.domain_name}"
   subject_alternative_names = ["${var.subject_alternative_names}"]
   validation_method         = "DNS"
+  tags                      = "${merge(map("Name", var.domain_name), var.acm_certificate_tags)}"
 }
 
 resource "aws_route53_record" "validation" {
-  count = "${length(var.subject_alternative_names) + 1}"
+  provider = "aws.route53_account"
+  count    = "${length(var.subject_alternative_names) + 1}"
 
   name    = "${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_name")}"
   type    = "${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_type")}"
@@ -15,6 +18,7 @@ resource "aws_route53_record" "validation" {
 }
 
 resource "aws_acm_certificate_validation" "default" {
+  provider        = "aws.acm_account"
   certificate_arn = "${aws_acm_certificate.default.arn}"
 
   validation_record_fqdns = [

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "aws_acm_certificate" "default" {
   domain_name               = "${var.domain_name}"
   subject_alternative_names = ["${var.subject_alternative_names}"]
   validation_method         = "DNS"
-  tags                      = "${merge(map("Name", var.domain_name), var.acm_certificate_tags)}"
+  tags                      = "${merge(map("Name", var.domain_name), var.tags)}"
 }
 
 resource "aws_route53_record" "validation" {

--- a/provider.tf
+++ b/provider.tf
@@ -6,6 +6,15 @@ provider "aws" {
   alias = "route53_account"
 }
 
-// Do not remove, this causes input prompts otherwise
-// known terraform bug
+/**
+ * Do not remove, this causes input prompts otherwise
+ * >At this time it is required to write an explicit 
+ * >proxy configuration block even for default (un-aliased)
+ * >provider configurations when they will be passed via
+ * >an explicit providers block
+ * 
+ * https://www.terraform.io/docs/modules/usage.html#passing-providers-explicitly
+ * https://git.io/fh0qw
+ */
+
 provider "aws" {}

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  alias = "acm_account"
+}
+
+provider "aws" {
+  alias = "route53_account"
+}
+
+// Do not remove, this causes input prompts otherwise
+// known terraform bug
+provider "aws" {}

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "validation_record_ttl" {
   default = "60"
 }
 
-variable "acm_certificate_tags" {
-  description = "map of tags to attach to the ACM certificate"
+variable "tags" {
+  description = "extra tags to attach to the ACM certificate"
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,23 @@
-variable "domain_name" {}
-
-variable "subject_alternative_names" {
-  type = "list"
+variable "domain_name" {
+  type        = "string"
+  description = "primary certificate domain name"
 }
 
-variable "hosted_zone_id" {}
+variable "subject_alternative_names" {
+  type    = "list"
+  default = []
+}
+
+variable "hosted_zone_id" {
+  type        = "string"
+  description = "Route53 Zone ID where DNS validation records will be created"
+}
 
 variable "validation_record_ttl" {
   default = "60"
+}
+
+variable "acm_certificate_tags" {
+  description = "map of tags to attach to the ACM certificate"
+  default     = {}
 }


### PR DESCRIPTION
- Allows you to pass multiple providers (assuming terraform 0.11)
  for your ACM and your Route53 AWS accounts.
- Also adds a simple acm_cert_tags parameter that can be used to
  add additional tags to your ACM Certificate.
- The `Name` tag is added by default (set to your default domain name)

WIP right now:

1. ~Testing the extra tags feature~ :checkered_flag:
2. Testing backward-compatibility with 0.10 (and see if it can support multiple providers there)