### PR TITLE
Add option for DNS validation record overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ module "cert" {
     aws.route53_account = "aws.dns"
   }
 
-  domain_name               = "azavea.com"
-  subject_alternative_names = ["*.azavea.com"]
-  hosted_zone_id            = "${aws_route53_zone.default.zone_id}"
-  validation_record_ttl     = "60"
+  domain_name                       = "azavea.com"
+  subject_alternative_names         = ["*.azavea.com"]
+  hosted_zone_id                    = "${aws_route53_zone.default.zone_id}"
+  validation_record_ttl             = "60"
+  allow_validation_record_overwrite = true
 }
 ```
 
@@ -40,6 +41,7 @@ module "cert" {
 - `subject_alternative_names` - Subject alternative domain names.
 - `hosted_zone_id` - Route 53 hosted zone ID for `domain_name`.
 - `validation_record_ttl` - Route 53 record time-to-live (TTL) for validation record (default: `60`).
+- `allow_validation_record_overwrite` - Allow Route 53 record creation to overwrite existing records (default: `true`).
 - `tags` - A map of extra tags that is associated with the ACM Certificate.
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -10,11 +10,12 @@ resource "aws_route53_record" "validation" {
   provider = "aws.route53_account"
   count    = "${length(var.subject_alternative_names) + 1}"
 
-  name    = "${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_name")}"
-  type    = "${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_type")}"
-  zone_id = "${var.hosted_zone_id}"
-  records = ["${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_value")}"]
-  ttl     = "${var.validation_record_ttl}"
+  name            = "${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_name")}"
+  type            = "${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_type")}"
+  zone_id         = "${var.hosted_zone_id}"
+  records         = ["${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_value")}"]
+  ttl             = "${var.validation_record_ttl}"
+  allow_overwrite = "${var.allow_validation_record_overwrite}"
 }
 
 resource "aws_acm_certificate_validation" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,11 @@ variable "validation_record_ttl" {
   description = "Route 53 time-to-live for validation records"
 }
 
+variable "allow_validation_record_overwrite" {
+  default     = "true"
+  description = "Allow Route 53 record creation to overwrite existing records"
+}
+
 variable "tags" {
   default     = {}
   description = "Extra tags to attach to the ACM certificate"


### PR DESCRIPTION
Changes to the `aws_route53_record` creation process made it so that DNS record overwrites now fail by default. In order to allow DNS record overwrites, the `allow_overwrite` attribute on the `aws_route53_record` resource must be enabled.

The `allow_validation_record_overwrite` variable was added to support setting the value of `allow_overwrite` at the module level.

See:

- https://github.com/terraform-providers/terraform-provider-aws/issues/7846
- https://github.com/terraform-providers/terraform-provider-aws/issues/7918

---

**Testing**

Please use https://github.com/azavea/robarts-histo/pull/35 to test.