### PR TITLE
upgrading via terraform 0.12upgrade

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,28 +1,32 @@
 resource "aws_acm_certificate" "default" {
-  provider                  = "aws.acm_account"
-  domain_name               = "${var.domain_name}"
-  subject_alternative_names = ["${var.subject_alternative_names}"]
+  provider                  = aws.acm_account
+  domain_name               = var.domain_name
+  subject_alternative_names = var.subject_alternative_names
   validation_method         = "DNS"
-  tags                      = "${merge(map("Name", var.domain_name), var.tags)}"
+  tags = merge(
+    {
+      "Name" = var.domain_name
+    },
+    var.tags,
+  )
 }
 
 resource "aws_route53_record" "validation" {
-  provider = "aws.route53_account"
-  count    = "${length(var.subject_alternative_names) + 1}"
+  provider = aws.route53_account
+  count    = length(var.subject_alternative_names) + 1
 
-  name            = "${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_name")}"
-  type            = "${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_type")}"
-  zone_id         = "${var.hosted_zone_id}"
-  records         = ["${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_value")}"]
-  ttl             = "${var.validation_record_ttl}"
-  allow_overwrite = "${var.allow_validation_record_overwrite}"
+  name    = aws_acm_certificate.default.domain_validation_options[count.index]["resource_record_name"]
+  type    = aws_acm_certificate.default.domain_validation_options[count.index]["resource_record_type"]
+  zone_id = var.hosted_zone_id
+  records         = [aws_acm_certificate.default.domain_validation_options[count.index]["resource_record_value"]]
+  ttl             = var.validation_record_ttl
+  allow_overwrite = var.allow_validation_record_overwrite
 }
 
 resource "aws_acm_certificate_validation" "default" {
-  provider        = "aws.acm_account"
-  certificate_arn = "${aws_acm_certificate.default.arn}"
+  provider        = aws.acm_account
+  certificate_arn = aws_acm_certificate.default.arn
 
-  validation_record_fqdns = [
-    "${aws_route53_record.validation.*.fqdn}",
-  ]
+  validation_record_fqdns = aws_route53_record.validation.*.fqdn
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
 output "arn" {
-  value = "${aws_acm_certificate_validation.default.certificate_arn}"
+  value = aws_acm_certificate_validation.default.certificate_arn
 }
+

--- a/provider.tf
+++ b/provider.tf
@@ -17,4 +17,6 @@ provider "aws" {
  * https://git.io/fh0qw
  */
 
-provider "aws" {}
+provider "aws" {
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,16 @@
 variable "domain_name" {
-  type        = "string"
+  type        = string
   description = "Primary certificate domain name"
 }
 
 variable "subject_alternative_names" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Subject alternative domain names"
 }
 
 variable "hosted_zone_id" {
-  type        = "string"
+  type        = string
   description = "Route 53 Zone ID for DNS validation records"
 }
 
@@ -28,3 +28,4 @@ variable "tags" {
   default     = {}
   description = "Extra tags to attach to the ACM certificate"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Upgrading the module to support terraform v0.12. This is pretty much an automatic change, achieved by running the `terraform 0.12upgrade` command and cleaning up the single TF-UPGRADE-TODO generated by the tool (in the end, no action was required for that case).

With people migrating to terraform v0.12, I think this might be useful to merge, as it solves issue https://github.com/azavea/terraform-aws-acm-certificate/issues/10