### PR TITLE
Add support for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: hashicorp/terraform:latest
+
+    steps:
+      - checkout
+      - run:
+          name: Install Bash
+          command: apk add --no-cache bash
+      - run:
+          name: Execute cibuild
+          command: ./scripts/cibuild

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # terraform-aws-acm-certificate
 
+[![CircleCI](https://circleci.com/gh/azavea/terraform-aws-acm-certificate.svg?style=svg)](https://circleci.com/gh/azavea/terraform-aws-acm-certificate)
+
 A Terraform module to create an Amazon Certificate Manager (ACM) certificate with Route 53 DNS validation.
 
 ## Usage

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${CI_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+    "Usage: $(basename "$0")
+Ensure the Terraform source code is properly formatted.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        terraform fmt -check
+    fi
+fi


### PR DESCRIPTION
Execute a Terraform formatting check via CircleCI.

---

**Testing**

See: https://circleci.com/gh/azavea/workflows/terraform-aws-acm-certificate