### PR TITLE
Upgrade module to support Terraform 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A Terraform module to create an Amazon Certificate Manager (ACM) certificate wit
 
 ## Usage
 
+When making use of this module, ensure that either the `AWS_DEFAULT_REGION` or `AWS_REGION` environment variable is set. This helps bypass [validation checks](https://github.com/hashicorp/terraform/issues/21408) that want the `provider` blocks within this module to have a `region` attribute specified.
+
 ```hcl
 provider "aws" {
   region = "us-east-1"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ resource "aws_route53_zone" "default" {
 }
 
 module "cert" {
-  source = "github.com/azavea/terraform-aws-acm-certificate?ref=1.1.0"
+  source = "github.com/azavea/terraform-aws-acm-certificate"
 
   providers = {
     aws.acm_account     = "aws.certificates"

--- a/main.tf
+++ b/main.tf
@@ -1,28 +1,32 @@
 resource "aws_acm_certificate" "default" {
-  provider                  = "aws.acm_account"
-  domain_name               = "${var.domain_name}"
-  subject_alternative_names = ["${var.subject_alternative_names}"]
+  provider                  = aws.acm_account
+  domain_name               = var.domain_name
+  subject_alternative_names = var.subject_alternative_names
   validation_method         = "DNS"
-  tags                      = "${merge(map("Name", var.domain_name), var.tags)}"
+  tags = merge(
+    {
+      "Name" = var.domain_name
+    },
+    var.tags,
+  )
 }
 
 resource "aws_route53_record" "validation" {
-  provider = "aws.route53_account"
-  count    = "${length(var.subject_alternative_names) + 1}"
+  provider = aws.route53_account
+  count    = length(var.subject_alternative_names) + 1
 
-  name            = "${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_name")}"
-  type            = "${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_type")}"
-  zone_id         = "${var.hosted_zone_id}"
-  records         = ["${lookup(aws_acm_certificate.default.domain_validation_options[count.index], "resource_record_value")}"]
-  ttl             = "${var.validation_record_ttl}"
-  allow_overwrite = "${var.allow_validation_record_overwrite}"
+  name    = aws_acm_certificate.default.domain_validation_options[count.index]["resource_record_name"]
+  type    = aws_acm_certificate.default.domain_validation_options[count.index]["resource_record_type"]
+  zone_id = var.hosted_zone_id
+  records         = [aws_acm_certificate.default.domain_validation_options[count.index]["resource_record_value"]]
+  ttl             = var.validation_record_ttl
+  allow_overwrite = var.allow_validation_record_overwrite
 }
 
 resource "aws_acm_certificate_validation" "default" {
-  provider        = "aws.acm_account"
-  certificate_arn = "${aws_acm_certificate.default.arn}"
+  provider        = aws.acm_account
+  certificate_arn = aws_acm_certificate.default.arn
 
-  validation_record_fqdns = [
-    "${aws_route53_record.validation.*.fqdn}",
-  ]
+  validation_record_fqdns = aws_route53_record.validation.*.fqdn
 }
+

--- a/main.tf
+++ b/main.tf
@@ -3,9 +3,10 @@ resource "aws_acm_certificate" "default" {
   domain_name               = var.domain_name
   subject_alternative_names = var.subject_alternative_names
   validation_method         = "DNS"
+
   tags = merge(
     {
-      "Name" = var.domain_name
+      Name = var.domain_name
     },
     var.tags,
   )

--- a/main.tf
+++ b/main.tf
@@ -15,9 +15,9 @@ resource "aws_route53_record" "validation" {
   provider = aws.route53_account
   count    = length(var.subject_alternative_names) + 1
 
-  name    = aws_acm_certificate.default.domain_validation_options[count.index]["resource_record_name"]
-  type    = aws_acm_certificate.default.domain_validation_options[count.index]["resource_record_type"]
-  zone_id = var.hosted_zone_id
+  name            = aws_acm_certificate.default.domain_validation_options[count.index]["resource_record_name"]
+  type            = aws_acm_certificate.default.domain_validation_options[count.index]["resource_record_type"]
+  zone_id         = var.hosted_zone_id
   records         = [aws_acm_certificate.default.domain_validation_options[count.index]["resource_record_value"]]
   ttl             = var.validation_record_ttl
   allow_overwrite = var.allow_validation_record_overwrite
@@ -29,4 +29,3 @@ resource "aws_acm_certificate_validation" "default" {
 
   validation_record_fqdns = aws_route53_record.validation.*.fqdn
 }
-

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,9 @@ resource "aws_acm_certificate" "default" {
 
   tags = merge(
     {
-      Name = var.domain_name
+      Name        = var.domain_name,
+      Project     = var.project,
+      Environment = var.environment
     },
     var.tags,
   )

--- a/main.tf
+++ b/main.tf
@@ -6,9 +6,7 @@ resource "aws_acm_certificate" "default" {
 
   tags = merge(
     {
-      Name        = var.domain_name,
-      Project     = var.project,
-      Environment = var.environment
+      Name = var.domain_name
     },
     var.tags,
   )

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
 output "arn" {
-  value = "${aws_acm_certificate_validation.default.certificate_arn}"
+  value = aws_acm_certificate_validation.default.certificate_arn
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,3 @@
 output "arn" {
   value = aws_acm_certificate_validation.default.certificate_arn
 }
-

--- a/provider.tf
+++ b/provider.tf
@@ -17,4 +17,6 @@ provider "aws" {
  * https://git.io/fh0qw
  */
 
-provider "aws" {}
+provider "aws" {
+}
+

--- a/provider.tf
+++ b/provider.tf
@@ -5,18 +5,3 @@ provider "aws" {
 provider "aws" {
   alias = "route53_account"
 }
-
-/**
- * Do not remove, this causes input prompts otherwise
- * >At this time it is required to write an explicit 
- * >proxy configuration block even for default (un-aliased)
- * >provider configurations when they will be passed via
- * >an explicit providers block
- * 
- * https://www.terraform.io/docs/modules/usage.html#passing-providers-explicitly
- * https://git.io/fh0qw
- */
-
-provider "aws" {
-}
-

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -3,20 +3,20 @@
 set -e
 
 if [[ -n "${CI_DEBUG}" ]]; then
-    set -x
+	set -x
 fi
 
 function usage() {
-    echo -n \
-    "Usage: $(basename "$0")
+	echo -n \
+		"Usage: $(basename "$0")
 Ensure the Terraform source code is properly formatted.
 "
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
-    if [ "${1:-}" = "--help" ]; then
-        usage
-    else
-        terraform fmt -check
-    fi
+	if [ "${1:-}" = "--help" ]; then
+		usage
+	else
+		terraform fmt -check
+	fi
 fi

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,16 @@
 variable "domain_name" {
-  type        = "string"
+  type        = string
   description = "Primary certificate domain name"
 }
 
 variable "subject_alternative_names" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Subject alternative domain names"
 }
 
 variable "hosted_zone_id" {
-  type        = "string"
+  type        = string
   description = "Route 53 Zone ID for DNS validation records"
 }
 
@@ -28,3 +28,4 @@ variable "tags" {
   default     = {}
   description = "Extra tags to attach to the ACM certificate"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -4,8 +4,8 @@ variable "domain_name" {
 }
 
 variable "subject_alternative_names" {
-  type        = list(string)
   default     = []
+  type        = list(string)
   description = "Subject alternative domain names"
 }
 
@@ -15,17 +15,20 @@ variable "hosted_zone_id" {
 }
 
 variable "validation_record_ttl" {
-  default     = "60"
+  default     = 60
+  type        = number
   description = "Route 53 time-to-live for validation records"
 }
 
 variable "allow_validation_record_overwrite" {
-  default     = "true"
+  default     = true
+  type        = bool
   description = "Allow Route 53 record creation to overwrite existing records"
 }
 
 variable "tags" {
   default     = {}
+  type        = map(string)
   description = "Extra tags to attach to the ACM certificate"
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.12"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,6 @@
 terraform {
   required_version = ">= 0.12"
+  required_providers {
+    aws = ">= 2.33.0"
+  }
 }


### PR DESCRIPTION
Following the instructions outlined in the [Terraform documentation](https://www.terraform.io/upgrade-guides/0-12.html), update the module's configuration to support Terraform 0.12. Despite containing minor changes, this is expected to cause a major version bump, because the changes are not backwards compatible.

Builds on https://github.com/azavea/terraform-aws-acm-certificate/pull/11.
Fixes https://github.com/azavea/terraform-aws-acm-certificate/issues/10
Fixes https://github.com/azavea/terraform-aws-acm-certificate/issues/12

---

**Testing**

Please use https://github.com/azavea/azavea-data-hub/pull/60 to test this PR.