### PR TITLE
Update to support terraform AWS provider v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+- Adjust for terraform aws provider version 3.0.0
+
 ## 2.0.1
 
 - Add `create_before_destroy` lifecycle block to `aws_acm_certificate`.

--- a/main.tf
+++ b/main.tf
@@ -18,12 +18,18 @@ resource "aws_acm_certificate" "default" {
 
 resource "aws_route53_record" "validation" {
   provider = aws.route53_account
-  count    = length(var.subject_alternative_names) + 1
+  for_each = {
+    for dvo in aws_acm_certificate.default.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
 
-  name            = aws_acm_certificate.default.domain_validation_options[count.index]["resource_record_name"]
-  type            = aws_acm_certificate.default.domain_validation_options[count.index]["resource_record_type"]
+  name            = each.value.name
+  type            = each.value.type
   zone_id         = var.hosted_zone_id
-  records         = [aws_acm_certificate.default.domain_validation_options[count.index]["resource_record_value"]]
+  records         = [each.value.record]
   ttl             = var.validation_record_ttl
   allow_overwrite = var.allow_validation_record_overwrite
 }
@@ -32,5 +38,5 @@ resource "aws_acm_certificate_validation" "default" {
   provider        = aws.acm_account
   certificate_arn = aws_acm_certificate.default.arn
 
-  validation_record_fqdns = aws_route53_record.validation.*.fqdn
+  validation_record_fqdns = [for record in aws_route53_record.validation : record.fqdn]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    aws = ">= 2.33.0"
+    aws = ">= 3.0.0"
   }
 }


### PR DESCRIPTION
A few days ago the new [v3.0.0](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#300-july-31-2020) of the aws terraform provider has been released

Relevant changes for this module include:
- resource/aws_acm_certificate: domain_validation_options attribute changed from list to set (#14199)

As such see the attached PR to adjust this module to support the new syntax