### PR TITLE
Use configuration_aliases to define alternative providers

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,7 +1,0 @@
-provider "aws" {
-  alias = "acm_account"
-}
-
-provider "aws" {
-  alias = "route53_account"
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,9 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.15"
   required_providers {
-    aws = ">= 3.0.0"
+    aws = {
+      version               = ">= 3.0.0"
+      configuration_aliases = [aws.acm_account, aws.route53_account]
+    }
   }
 }


### PR DESCRIPTION
Previous versions of Terraform [required](https://github.com/azavea/terraform-aws-acm-certificate/pull/6#issuecomment-455703773) an empty "proxy configuration block" to declare multiple configuration names for a provider within a module. Terraform 0.15 [adds a new field](https://www.terraform.io/upgrade-guides/0-15.html#alternative-provider-configurations-within-modules) to the `required_providers` block for providers to indicate aliased configuration names. Using the `configuration_aliases` argument resolves warnings emitted when this module is used on newer versions of Terraform.

Resolves #17 

---

**Testing**

See: https://github.com/azavea/fieldscope/pull/962
